### PR TITLE
Added the missed "update transactional data" method from the API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "romanpitak/dotmailer-api-v2-client",
+    "name": "willitscale/dotmailer-api-v2-client",
     "type": "library",
     "description": "Client library for the dotMailer v2 (REST) API.",
     "keywords": [
@@ -10,7 +10,7 @@
         "version 2",
         "client"
     ],
-    "homepage": "https://github.com/romanpitak/dotMailer-API-v2-PHP-client",
+    "homepage": "https://github.com/willitscale/dotMailer-API-v2-PHP-client",
     "license": "MIT",
     "authors": [
         {
@@ -23,7 +23,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/romanpitak/PHP-REST-Client.git"
+            "url": "https://github.com/willitscale/PHP-REST-Client.git"
         }
     ],
     "require": {

--- a/src/Resources/Resources.php
+++ b/src/Resources/Resources.php
@@ -469,6 +469,12 @@ final class Resources implements IResources
         return new ApiTransactionalData($this->execute($url, 'POST', $apiTransactionalData->toJson()));
     }
 
+    public function PostContactsTransactionalDataUpdate($collectionName, $importId, ApiJsonData $apiJsonData)
+    {
+        $url = sprintf("contacts/transactional-data/%s/%s", $collectionName, $importId);
+        return new ApiTransactionalData($this->execute($url, 'POST', $apiJsonData>toJson()));
+    }
+
     public function DeleteContactsTransactionalData($collectionName, $key)
     {
         $url = sprintf("contacts/transactional-data/%s/%s", $collectionName, $key);


### PR DESCRIPTION
There are two POST methods for contacts transactional-data for the DotMailer V2 API:
https://api.dotmailer.com/v2/contacts/transactional-data/{collectionName} - Adds a single piece of transactional data to a contact.
https://api.dotmailer.com/v2/contacts/transactional-data/{collectionName}/{key} - Replaces a piece of transactional data by key (logicall equivalent to a delete and an insert).

I've added to the update POST to the resources.
