### PR TITLE
Replace transactional data

### DIFF
--- a/src/Resources/IResources.php
+++ b/src/Resources/IResources.php
@@ -44,6 +44,7 @@ use DotMailer\Api\DataTypes\ApiFileMedia;
 use DotMailer\Api\DataTypes\ApiImage;
 use DotMailer\Api\DataTypes\ApiImageFolder;
 use DotMailer\Api\DataTypes\ApiImageFolderList;
+use DotMailer\Api\DataTypes\ApiJsonData;
 use DotMailer\Api\DataTypes\ApiResubscribeResult;
 use DotMailer\Api\DataTypes\ApiSegmentList;
 use DotMailer\Api\DataTypes\ApiSegmentRefresh;
@@ -671,13 +672,24 @@ interface IResources
      * Adds a single piece of transactional data to a contact.
      *
      * /contacts/transactional-data/{collectionName}
-     * todo maybe look at contacts/transactional-data/{collectionName}/{key}
      *
      * @param string|XsString $collectionName
      * @param ApiTransactionalData $apiTransactionalData
      * @return ApiTransactionalData
      */
     public function PostContactsTransactionalData($collectionName, ApiTransactionalData $apiTransactionalData);
+
+    /**
+     * Replaces a piece of transactional data by key (logical equivalent to a delete and an insert).
+     *
+     * /contacts/transactional-data/{collectionName}/{key}
+     *
+     * @param string|XsString $collectionName
+     * @param int|XsInt $importId
+     * @param ApiJsonData $apiJsonData
+     * @return ApiTransactionalData
+     */
+    public function PostContactsTransactionalDataUpdate($collectionName, $importId, ApiJsonData $apiJsonData);
 
     /**
      * Deletes a piece of transactional data by key.

--- a/src/Resources/Resources.php
+++ b/src/Resources/Resources.php
@@ -43,6 +43,7 @@ use DotMailer\Api\DataTypes\ApiFileMedia;
 use DotMailer\Api\DataTypes\ApiImage;
 use DotMailer\Api\DataTypes\ApiImageFolder;
 use DotMailer\Api\DataTypes\ApiImageFolderList;
+use DotMailer\Api\DataTypes\ApiJsonData;
 use DotMailer\Api\DataTypes\ApiResubscribeResult;
 use DotMailer\Api\DataTypes\ApiSegmentList;
 use DotMailer\Api\DataTypes\ApiSegmentRefresh;
@@ -467,6 +468,12 @@ final class Resources implements IResources
     {
         $url = sprintf("contacts/transactional-data/%s", $collectionName);
         return new ApiTransactionalData($this->execute($url, 'POST', $apiTransactionalData->toJson()));
+    }
+
+    public function PostContactsTransactionalDataUpdate($collectionName, $importId, ApiJsonData $apiJsonData)
+    {
+        $url = sprintf("contacts/transactional-data/%s/%s", $collectionName, $importId);
+        return new ApiTransactionalData($this->execute($url, 'POST', $apiJsonData->toJson()));
     }
 
     public function DeleteContactsTransactionalData($collectionName, $key)


### PR DESCRIPTION
Added functionality to replace a piece of transactional data

The API docs uses the same method name with a different number of parameters. So we had to split out it to a separate method

https://api.dotmailer.com/v2/help/wadl#ContactsTransactionalData