### PR TITLE
Added the JsonNumberValueTooLarge failure critera...

### DIFF
--- a/src/DataTypes/ApiTransactionalDataImportFaultReason.php
+++ b/src/DataTypes/ApiTransactionalDataImportFaultReason.php
@@ -23,6 +23,7 @@ final class ApiTransactionalDataImportFaultReason extends Enum
     const JSON_KEY_TOO_LONG = 'JsonKeyTooLong';
     const JSON_KEY_INVALID_CHARACTERS = 'JsonKeyInvalidCharacters';
     const JSON_VALUE_TOO_LONG = 'JsonValueTooLong';
+    const JSON_VALUE_TOO_LARGE = 'JsonNumberValueTooLarge';
     const JSON_VALUE_INCOMPATIBLE_WITH_SCHEMA = 'JsonValueIncompatibleWithSchema';
     const NOT_AVAILABLE_IN_THIS_VERSION = 'NotAvailableInThisVersion';
 
@@ -44,6 +45,7 @@ final class ApiTransactionalDataImportFaultReason extends Enum
             self::JSON_KEY_TOO_LONG,
             self::JSON_KEY_INVALID_CHARACTERS,
             self::JSON_VALUE_TOO_LONG,
+            self::JSON_VALUE_TOO_LARGE,
             self::JSON_VALUE_INCOMPATIBLE_WITH_SCHEMA,
             self::NOT_AVAILABLE_IN_THIS_VERSION
         );

--- a/src/DataTypes/ApiTransactionalDataImportFaultReason.php
+++ b/src/DataTypes/ApiTransactionalDataImportFaultReason.php
@@ -22,8 +22,8 @@ final class ApiTransactionalDataImportFaultReason extends Enum
     const CONTACT_EMAIL_DOES_NOT_EXIST = 'ContactEmailDoesNotExist';
     const JSON_KEY_TOO_LONG = 'JsonKeyTooLong';
     const JSON_KEY_INVALID_CHARACTERS = 'JsonKeyInvalidCharacters';
+    const JSON_NUMBER_VALUE_TOO_LARGE = 'JsonNumberValueTooLarge';
     const JSON_VALUE_TOO_LONG = 'JsonValueTooLong';
-    const JSON_VALUE_TOO_LARGE = 'JsonNumberValueTooLarge';
     const JSON_VALUE_INCOMPATIBLE_WITH_SCHEMA = 'JsonValueIncompatibleWithSchema';
     const NOT_AVAILABLE_IN_THIS_VERSION = 'NotAvailableInThisVersion';
 
@@ -44,8 +44,8 @@ final class ApiTransactionalDataImportFaultReason extends Enum
             self::CONTACT_EMAIL_DOES_NOT_EXIST,
             self::JSON_KEY_TOO_LONG,
             self::JSON_KEY_INVALID_CHARACTERS,
+            self::JSON_NUMBER_VALUE_TOO_LARGE,
             self::JSON_VALUE_TOO_LONG,
-            self::JSON_VALUE_TOO_LARGE,
             self::JSON_VALUE_INCOMPATIBLE_WITH_SCHEMA,
             self::NOT_AVAILABLE_IN_THIS_VERSION
         );


### PR DESCRIPTION
Added the JsonNumberValueTooLarge failure critera to the ApiTransactionalDataImportFaultReason enum. 

If you pass a number which exceeds the maximum length of a number this error is thrown by the dot mailer API. If it's not set in this enum then InvalidValueException is thrown.