### PR TITLE
Fix problem with no calling "Get campaign send status" from Dotmailer

### DIFF
--- a/src/Resources/Resources.php
+++ b/src/Resources/Resources.php
@@ -357,7 +357,7 @@ final class Resources implements IResources
 
     public function GetCampaignsSendBySendId($sendId)
     {
-        return new ApiCampaignSend(sprintf("campaigns/send/%s", $sendId));
+        return new ApiCampaignSend($this->execute(sprintf("campaigns/send/%s", $sendId)));
     }
 
     public function GetCampaignsWithActivitySinceDate($dateTime, $select = 1000, $skip = 0)


### PR DESCRIPTION
There is some issue with Resources:GetCampaignsSendBySendId()
Currently on this line:
https://github.com/romanpitak/dotMailer-API-v2-PHP-client/blob/master/src/Resources/Resources.php#L360

There is no execution so request will not be send to Dotmailer as result we will have array.