### PR TITLE
Add support for the transactional email triggered campaign endpoint.

### DIFF
--- a/src/DataTypes/ApiEmailTriggeredCampaign.php
+++ b/src/DataTypes/ApiEmailTriggeredCampaign.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ *
+ *
+ * @author Steven Jones <steven.jones@computerminds.co.uk>
+ *
+ */
+
+
+namespace DotMailer\Api\DataTypes;
+
+/**
+ * Class ApiEmailTriggeredCampaign
+ *
+ * @property StringList ToAddresses
+ * @property StringList CCAddresses
+ * @property StringList BCCAddresses
+ * @property XsInt CampaignId
+ * @property ApiPersonalizationValueList PersonalizationValues
+ */
+final class ApiEmailTriggeredCampaign extends JsonObject implements IApiEmailTriggeredCampaign
+{
+
+    protected function getProperties()
+    {
+        return array(
+            'ToAddresses' => 'StringList',
+            'CCAddresses' => 'StringList',
+            'BCCAddresses' => 'StringList',
+            'CampaignId' => 'XsInt',
+            'PersonalizationValues' => 'ApiPersonalizationValueList',
+        );
+    }
+
+}

--- a/src/DataTypes/ApiPersonalizationValue.php
+++ b/src/DataTypes/ApiPersonalizationValue.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ *
+ *
+ * @author Steven Jones <steven.jones@computerminds.co.uk>
+ *
+ */
+
+
+namespace DotMailer\Api\DataTypes;
+
+final class ApiPersonalizationValue extends JsonObject
+{
+
+    protected function getProperties()
+    {
+        return array(
+            'Name' => 'XsString',
+            'Value' => 'XsString',
+        );
+    }
+
+}

--- a/src/DataTypes/ApiPersonalizationValueList.php
+++ b/src/DataTypes/ApiPersonalizationValueList.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ *
+ *
+ * @author Steven Jones <steven.jones@computerminds.co.uk>
+ *
+ */
+
+
+namespace DotMailer\Api\DataTypes;
+
+final class ApiPersonalizationValueList extends JsonArray
+{
+
+    protected function getDataClass()
+    {
+       return 'ApiPersonalizationValue';
+    }
+
+}

--- a/src/DataTypes/IApiEmailTriggeredCampaign.php
+++ b/src/DataTypes/IApiEmailTriggeredCampaign.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ *
+ * @author Steven Jones <steven.jones@computerminds.co.uk>
+ *
+ */
+
+namespace DotMailer\Api\DataTypes;
+
+/**
+ * Interface IApiEmailTriggeredCampaign
+ *
+ * @property StringList ToAddresses
+ * @property StringList CCAddresses
+ * @property StringList BCCAddresses
+ * @property XsInt CampaignId
+ * @property ApiPersonalizationValueList PersonalizationValues
+ */
+interface IApiEmailTriggeredCampaign extends IDataType
+{
+}

--- a/src/DataTypes/StringList.php
+++ b/src/DataTypes/StringList.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ *
+ *
+ * @author Steven Jones <steven.jones@computerminds.co.uk>
+ *
+ */
+
+
+namespace DotMailer\Api\DataTypes;
+
+final class StringList extends JsonArray
+{
+
+    protected function getDataClass()
+    {
+       return 'XsString';
+    }
+
+}

--- a/src/Resources/IResources.php
+++ b/src/Resources/IResources.php
@@ -59,6 +59,7 @@ use DotMailer\Api\DataTypes\ApiTransactionalDataImport;
 use DotMailer\Api\DataTypes\ApiTransactionalDataImportReport;
 use DotMailer\Api\DataTypes\ApiTransactionalDataList;
 use DotMailer\Api\DataTypes\Guid;
+use DotMailer\Api\DataTypes\IApiEmailTriggeredCampaign;
 use DotMailer\Api\DataTypes\IApiTemplate;
 use DotMailer\Api\DataTypes\Int32List;
 use DotMailer\Api\DataTypes\XsBoolean;
@@ -1024,4 +1025,10 @@ interface IResources
      */
     public function GetTemplates($select = 1000, $skip = 0);
 
+    /**
+     * Send a triggered email campaign.
+     *
+     * @param IApiEmailTriggeredCampaign $apiEmailTriggeredCampaign
+     */
+    public function PostEmailTriggeredCampaign(IApiEmailTriggeredCampaign $apiEmailTriggeredCampaign);
 }

--- a/src/Resources/Resources.php
+++ b/src/Resources/Resources.php
@@ -59,6 +59,7 @@ use DotMailer\Api\DataTypes\ApiTransactionalDataImport;
 use DotMailer\Api\DataTypes\ApiTransactionalDataImportReport;
 use DotMailer\Api\DataTypes\ApiTransactionalDataList;
 use DotMailer\Api\DataTypes\Guid;
+use DotMailer\Api\DataTypes\IApiEmailTriggeredCampaign;
 use DotMailer\Api\DataTypes\IApiTemplate;
 use DotMailer\Api\DataTypes\XsDateTime;
 use DotMailer\Api\DataTypes\XsInt;
@@ -718,5 +719,14 @@ final class Resources implements IResources
     {
         $url = sprintf("templates?select=%s&skip=%s", $select, $skip);
         return new ApiTemplateList($this->execute($url));
+    }
+
+    /*
+     * ========== Email ==========
+     */
+
+    public function PostEmailTriggeredCampaign(IApiEmailTriggeredCampaign $apiEmailTriggeredCampaign)
+    {
+        $this->execute('email/triggered-campaign', 'POST', $apiEmailTriggeredCampaign->toJson());
     }
 }


### PR DESCRIPTION
This code adds support for the transactional email triggered campaign endpoint:

https://developer.dotmailer.com/docs/send-transactional-email-using-a-triggered-campaign

Essentially this is a simple PR that defines the data types required for this API call, and adds the single method to the resources class so that it's callable etc.