### PR TITLE
wrapped XsDateTime value with quotes when output for JSON

### DIFF
--- a/src/DataTypes/XsDateTime.php
+++ b/src/DataTypes/XsDateTime.php
@@ -21,7 +21,7 @@ final class XsDateTime implements IDataType
 
     public function toJson()
     {
-        return (string)$this->value;
+        return '"'.(string)$this->value.'"';
     }
 
     public function __toString()


### PR DESCRIPTION
When outputting an object to JSON, if it contains an XsDateTime object, the resulting JSON wasn't valid as the date string wasn't being wrapped in double quotes.  This commit fixes that issue.